### PR TITLE
Support pykokkos-base as subproject with existing kokkos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ PROJECT(
     LANGUAGES   C CXX
     VERSION     ${pykokkos-base_VERSION})
 
+IF("${CMAKE_SOURCE_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
+    SET(PYKOKKOS_BASE_MAIN_PROJECT ON)
+ELSE()
+    SET(PYKOKKOS_BASE_MAIN_PROJECT OFF)
+ENDIF()
+
 INCLUDE(KokkosPythonUtilities)  # miscellaneous macros and functions
 
 ADD_OPTION(BUILD_SHARED_LIBS "Build shared libraries" ON)

--- a/cmake/Modules/KokkosPythonOptions.cmake
+++ b/cmake/Modules/KokkosPythonOptions.cmake
@@ -49,11 +49,14 @@ ADD_OPTION(ENABLE_LAYOUTS "Build support for layouts (long NVCC compile times)"
 ADD_OPTION(ENABLE_MEMORY_TRAITS "Build support for memory traits (long NVCC compile times)"
     ${_ENABLE_MEM_DEFAULT})
 ADD_OPTION(ENABLE_PRECOMPILED_HEADERS "Enable precompiling kokkos and pybind11 headers" OFF)
-ADD_OPTION(CMAKE_UNITY_BUILD "Enable unity build" ${_UNITY_BUILD})
 
-IF(CMAKE_UNITY_BUILD)
-    SET(CMAKE_UNITY_BUILD_BATCH_SIZE 8 CACHE STRING "Unity build batch size")
-    ADD_FEATURE(CMAKE_UNITY_BUILD_BATCH_SIZE "Unity build batch size")
+IF(PYKOKKOS_BASE_MAIN_PROJECT)
+    ADD_OPTION(CMAKE_UNITY_BUILD "Enable unity build" ${_UNITY_BUILD})
+
+    IF(CMAKE_UNITY_BUILD)
+        SET(CMAKE_UNITY_BUILD_BATCH_SIZE 8 CACHE STRING "Unity build batch size")
+        ADD_FEATURE(CMAKE_UNITY_BUILD_BATCH_SIZE "Unity build batch size")
+    ENDIF()
 ENDIF()
 
 SET(ENABLE_VIEW_RANKS "4" CACHE STRING "${_VIEW_RANK_MSG}")

--- a/cmake/Modules/KokkosPythonPackages.cmake
+++ b/cmake/Modules/KokkosPythonPackages.cmake
@@ -47,7 +47,7 @@ ADD_FEATURE(Python3_INCLUDE_DIR "Python include directory")
 ADD_FEATURE(Python3_LIBRARY "Python library")
 
 # python binding library
-IF(ENABLE_INTERNAL_PYBIND11)
+IF(ENABLE_INTERNAL_PYBIND11 AND NOT TARGET pybind11::pybind11)
     CHECKOUT_GIT_SUBMODULE(
         RECURSIVE
         RELATIVE_PATH     external/pybind11
@@ -57,7 +57,7 @@ IF(ENABLE_INTERNAL_PYBIND11)
         REPO_BRANCH       master)
     ADD_SUBDIRECTORY(external/pybind11)
     SET(pybind11_INCLUDE_DIR external/pybind11/include)
-ELSE()
+ELSEIF(NOT TARGET pybind11::pybind11)
     FIND_PACKAGE(pybind11 REQUIRED)
 ENDIF()
 


### PR DESCRIPTION
Example:

```cmake
cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)

project(test LANGUAGES CXX)

add_subdirectory(kokkos)
add_subdirectory(pybind11)
add_subdirectory(pykokkos-base)
```