### PR TITLE
ENH: support int8

### DIFF
--- a/include/fwd.hpp
+++ b/include/fwd.hpp
@@ -123,7 +123,8 @@ struct Device;
 //----------------------------------------------------------------------------//
 
 enum KokkosViewDataType {
-  Int16 = 0,
+  Int8 = 0,
+  Int16,
   Int32,
   Int64,
   Uint16,

--- a/include/traits.hpp
+++ b/include/traits.hpp
@@ -75,7 +75,7 @@ VIEW_DATA_DIMS(8, T ********)
 //  the first string identifier is the "canonical name" (i.e. what gets encoded)
 //  and the remaining string entries are used to generate aliases
 //
-VIEW_DATA_TYPE(int8_t, Int8, "int8", "short_short")
+VIEW_DATA_TYPE(int8_t, Int8, "int8", "signed_char")
 VIEW_DATA_TYPE(int16_t, Int16, "int16", "short")
 VIEW_DATA_TYPE(int32_t, Int32, "int32", "int")
 VIEW_DATA_TYPE(int64_t, Int64, "int64", "long")

--- a/include/traits.hpp
+++ b/include/traits.hpp
@@ -75,6 +75,7 @@ VIEW_DATA_DIMS(8, T ********)
 //  the first string identifier is the "canonical name" (i.e. what gets encoded)
 //  and the remaining string entries are used to generate aliases
 //
+VIEW_DATA_TYPE(int8_t, Int8, "int8", "short_short")
 VIEW_DATA_TYPE(int16_t, Int16, "int16", "short")
 VIEW_DATA_TYPE(int32_t, Int32, "int32", "int")
 VIEW_DATA_TYPE(int64_t, Int64, "int64", "long")

--- a/kokkos/__init__.py.in
+++ b/kokkos/__init__.py.in
@@ -147,7 +147,8 @@ try:
         "read_dtype",
         "initialize",  # bindings
         "finalize",
-        "int16",  # data types
+        "int8",  # data types
+        "int16",
         "int32",
         "int64",
         "uint16",

--- a/kokkos/test/test_types.py
+++ b/kokkos/test/test_types.py
@@ -4,28 +4,29 @@ import numpy as np
 import pytest
 
 
-@pytest.mark.parametrize("type_val, expected_np_type", [
-    (kokkos.int8, np.int8),
-    (kokkos.int16, np.int16),
-    (kokkos.int32, np.int32),
-    (kokkos.int64, np.int64),
-    (kokkos.uint16, np.uint16),
-    (kokkos.uint32, np.uint32),
-    (kokkos.uint64, np.uint64),
-    (kokkos.float32, np.float32),
-    (kokkos.float64, np.float64),
-    (kokkos.float, np.float32),
-    (kokkos.double, np.float64),
-    (kokkos.short, np.int16),
-    (kokkos.int, np.int32),
-    (kokkos.long, np.int64),
-])
+@pytest.mark.parametrize(
+    "type_val, expected_np_type",
+    [
+        (kokkos.int8, np.int8),
+        (kokkos.int16, np.int16),
+        (kokkos.int32, np.int32),
+        (kokkos.int64, np.int64),
+        (kokkos.uint16, np.uint16),
+        (kokkos.uint32, np.uint32),
+        (kokkos.uint64, np.uint64),
+        (kokkos.float32, np.float32),
+        (kokkos.float64, np.float64),
+        (kokkos.float, np.float32),
+        (kokkos.double, np.float64),
+        (kokkos.short, np.int16),
+        (kokkos.int, np.int32),
+        (kokkos.long, np.int64),
+    ],
+)
 def test_basic_type_equiv(type_val, expected_np_type):
     # test some view to NumPy array type equivalencies
     kokkos.initialize()
-    view = kokkos.array([2],
-                        dtype=type_val,
-                        space=kokkos.DefaultHostMemorySpace)
+    view = kokkos.array([2], dtype=type_val, space=kokkos.DefaultHostMemorySpace)
 
     # NOTE: copy can still happen (attempt no copy,
     # not guarantee)

--- a/kokkos/test/test_types.py
+++ b/kokkos/test/test_types.py
@@ -1,0 +1,33 @@
+import kokkos
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize("type_val, expected_np_type", [
+    (kokkos.int8, np.int8),
+    (kokkos.int16, np.int16),
+    (kokkos.int32, np.int32),
+    (kokkos.int64, np.int64),
+    (kokkos.uint16, np.uint16),
+    (kokkos.uint32, np.uint32),
+    (kokkos.uint64, np.uint64),
+    (kokkos.float32, np.float32),
+    (kokkos.float64, np.float64),
+    (kokkos.float, np.float32),
+    (kokkos.double, np.float64),
+    (kokkos.short, np.int16),
+    (kokkos.int, np.int32),
+    (kokkos.long, np.int64),
+])
+def test_basic_type_equiv(type_val, expected_np_type):
+    # test some view to NumPy array type equivalencies
+    kokkos.initialize()
+    view = kokkos.array([2],
+                        dtype=type_val,
+                        space=kokkos.DefaultHostMemorySpace)
+
+    # NOTE: copy can still happen (attempt no copy,
+    # not guarantee)
+    arr = np.array(view, copy=False)
+    assert arr.dtype == expected_np_type

--- a/kokkos/utility.py
+++ b/kokkos/utility.py
@@ -81,6 +81,8 @@ def read_dtype(_dtype):
     try:
         import numpy as np
 
+        if _dtype == np.int8:
+            return lib.int8
         if _dtype == np.int16:
             return lib.int16
         elif _dtype == np.int32:

--- a/src/variants/CMakeLists.txt
+++ b/src/variants/CMakeLists.txt
@@ -26,7 +26,7 @@ TARGET_LINK_LIBRARIES(libpykokkos-variants PUBLIC
 
 SET(_types              concrete dynamic)
 SET(_variants           layout memory_trait)
-SET(_data_types         Int16 Int32 Int64 Uint16 Uint32 Uint64 Float32 Float64)
+SET(_data_types         Int8 Int16 Int32 Int64 Uint16 Uint32 Uint64 Float32 Float64)
 
 SET(layout_enums        Right)
 SET(memory_trait_enums  Managed)


### PR DESCRIPTION
* add support for 8-bit signed integers with values that
should exist on the interval `[-128, 127]` for conformance
with the array API:
https://data-apis.org/array-api/latest/API_specification/data_types.html
https://github.com/kokkos/pykokkos/pull/57

* add a regression test for kokkos<->NumPy type equivalencies that
includes the new `int8` type; I was hoping to do some simple
arithmetic testing as well, but not sure how practical that is
within `pykokkos-base` proper (maybe defer that kind of thing
to `pykokkos`?)