### PR TITLE
MAINT, CI: Python 3.11 prep

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11.0-rc.1"]
         kokkos-branch: ['develop']
 
     steps:


### PR DESCRIPTION
Fixes #44 

* update the `pybind11` submodule to point to the
latest tagged release, `v2.10.0` (our current
`pybind11` version is not sufficient for Python `3.11`)

* add a CI entry for Python `3.11rc1`, which is now
ABI stable; also, Python `3.10` was missing from the
matrix, so I added a single entry for that version as well

* we may want to discuss reduced testing for i.e., Python `3.6`
or adopting NEP29 for Python support to keep testing/support sane, but
I'm avoiding that here for now