### PR TITLE
Sync pykokkos-base with kokkos version 3.7.00 commit d19aab9

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -123,6 +123,7 @@ jobs:
           --disable-memory-traits
           --enable-werror
           -- -DENABLE_EXAMPLES=ON
+          -- -j1
 
     - name: Import Test
       run:

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -119,7 +119,7 @@ jobs:
         python -m pip install pytest &&
         python setup.py install
           --enable-layouts
-          --enable-view-ranks=5
+          --enable-view-ranks=4
           --disable-memory-traits
           --enable-werror
           -- -DENABLE_EXAMPLES=ON

--- a/kokkos/test/views.py
+++ b/kokkos/test/views.py
@@ -70,7 +70,7 @@ class PyKokkosBaseViewsTests(unittest.TestCase):
 
     @classmethod
     def tearDownClass(self):
-        pass
+        kokkos.finalize()
 
     def setUp(self):
         pass

--- a/kokkos/test/views.py
+++ b/kokkos/test/views.py
@@ -70,7 +70,8 @@ class PyKokkosBaseViewsTests(unittest.TestCase):
 
     @classmethod
     def tearDownClass(self):
-        kokkos.finalize()
+        if not kokkos.is_finalized():
+            kokkos.finalize()
 
     def setUp(self):
         pass

--- a/src/libpykokkos.cpp
+++ b/src/libpykokkos.cpp
@@ -103,8 +103,7 @@ PYBIND11_MODULE(libpykokkos, kokkos) {
 
   kokkos.def("is_initialized", &Kokkos::is_initialized,
              "Query initialization state");
-  kokkos.def("is_finalized", &Kokkos::is_finalized,
-             "Query finalization state");
+  kokkos.def("is_finalized", &Kokkos::is_finalized, "Query finalization state");
   kokkos.def("initialize", _initialize, "Initialize Kokkos");
   kokkos.def("finalize", _finalize, "Finalize Kokkos");
 

--- a/src/libpykokkos.cpp
+++ b/src/libpykokkos.cpp
@@ -103,6 +103,8 @@ PYBIND11_MODULE(libpykokkos, kokkos) {
 
   kokkos.def("is_initialized", &Kokkos::is_initialized,
              "Query initialization state");
+  kokkos.def("is_finalized", &Kokkos::is_finalized,
+             "Query finalization state");
   kokkos.def("initialize", _initialize, "Initialize Kokkos");
   kokkos.def("finalize", _finalize, "Finalize Kokkos");
 


### PR DESCRIPTION
Replaces #39. Will work with pykokkos once kokkos/pykokkos#109 is merged.