### PR TITLE
Add the C++ type to the bindings of `View` to enable explicit casting

### DIFF
--- a/include/views.hpp
+++ b/include/views.hpp
@@ -411,6 +411,10 @@ void generate_view(py::module &_mod, const std::string &_name,
       "dynamic", [](ViewT &) { return Kokkos::is_dyn_rank_view<ViewT>::value; },
       "Whether the rank is dynamic");
 
+  _view.def_property_readonly(
+      "cpp_type", [=](ViewT &) { return _msg; },
+      "Underlying C++ type as string");
+
   // support []
   generate_view_access<Tp>(_view, std::index_sequence<Idx...>{});
 }


### PR DESCRIPTION
As the views are represented as python objects when handled in python, it would be good to know the c++ type that they can be cast into, e.g. using the `.cast<Kokkos::View...>()` functionality.
If another library wants to write their own python bindings, they can use the explicit cast without having to figure out which c++ type the view they got passed as a python object is.