### PR TITLE
CI: use 3.11 final

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11.0-rc.1"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
         kokkos-branch: ['develop']
 
     steps:


### PR DESCRIPTION
* use Python 3.11 final release in CI now that it is available