### PR TITLE
WIP: add bool type (alias)

### DIFF
--- a/include/fwd.hpp
+++ b/include/fwd.hpp
@@ -134,6 +134,7 @@ enum KokkosViewDataType {
   Uint64,
   Float32,
   Float64,
+  Bool,
   ViewDataTypesEnd
 };
 

--- a/include/traits.hpp
+++ b/include/traits.hpp
@@ -75,6 +75,8 @@ VIEW_DATA_DIMS(8, T ********)
 //  the first string identifier is the "canonical name" (i.e. what gets encoded)
 //  and the remaining string entries are used to generate aliases
 //
+typedef uint8_t bool_t;
+
 VIEW_DATA_TYPE(int8_t, Int8, "int8", "signed_char")
 VIEW_DATA_TYPE(int16_t, Int16, "int16", "short")
 VIEW_DATA_TYPE(int32_t, Int32, "int32", "int")
@@ -85,6 +87,8 @@ VIEW_DATA_TYPE(uint32_t, Uint32, "uint32", "unsigned", "unsigned_int")
 VIEW_DATA_TYPE(uint64_t, Uint64, "uint64", "unsigned_long")
 VIEW_DATA_TYPE(float, Float32, "float32", "float")
 VIEW_DATA_TYPE(double, Float64, "float64", "double")
+// TODO: real bool type instead of alias
+VIEW_DATA_TYPE(bool_t, Bool, "bool", "bool_")
 
 //----------------------------------------------------------------------------//
 // <data-type> <enum> <string identifiers>

--- a/kokkos/__init__.py.in
+++ b/kokkos/__init__.py.in
@@ -166,6 +166,7 @@ try:
         "unsigned_long",
         "float",
         "double",
+        "bool",
         "Serial",  # devices
         "Threads",
         "OpenMP",

--- a/kokkos/utility.py
+++ b/kokkos/utility.py
@@ -101,6 +101,8 @@ def read_dtype(_dtype):
             return lib.float32
         elif _dtype == np.float64:
             return lib.float64
+        elif _dtype == np.bool_:
+            return lib.bool
     except ImportError:
         pass
 

--- a/src/variants/CMakeLists.txt
+++ b/src/variants/CMakeLists.txt
@@ -26,7 +26,7 @@ TARGET_LINK_LIBRARIES(libpykokkos-variants PUBLIC
 
 SET(_types              concrete dynamic)
 SET(_variants           layout memory_trait)
-SET(_data_types         Int8 Int16 Int32 Int64 Uint8 Uint16 Uint32 Uint64 Float32 Float64)
+SET(_data_types         Int8 Int16 Int32 Int64 Uint8 Uint16 Uint32 Uint64 Float32 Float64 Bool)
 
 SET(layout_enums        Right)
 SET(memory_trait_enums  Managed)


### PR DESCRIPTION
* I need a bool type for Python array API standard
conformance, and as far as I know Kokkos doesn't work
with such a view type under the hood?

* if I alias `bool_` and `bool` to the `uint8` type,
the conformance test suite can see through it, and
resolves the alias and fails my suite

* I'm trying another approach now, but this fails
i.e., the local `pykokkos-base` testsuite with
```
AttributeError: module 'kokkos.libpykokkos' has no attribute 'KokkosView_bool_HostSpace_LayoutRight_1'
```

* I'm not so sure either of these approaches really have many
prospects for success--I'm open to better ideas...

[skip ci]