### PR TITLE
minimal modif to run with kokkos 4.2.00

### DIFF
--- a/include/libpykokkos.hpp
+++ b/include/libpykokkos.hpp
@@ -44,9 +44,11 @@
 
 #pragma once
 
-#include "common.hpp"
-
 #include <pybind11/pybind11.h>
+
+#include <iostream>
+
+#include "common.hpp"
 
 namespace py = pybind11;
 

--- a/include/pools.hpp
+++ b/include/pools.hpp
@@ -46,6 +46,7 @@
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Random.hpp>
+#include <iostream>
 
 namespace Common {
 template <typename PoolT, typename Sp>

--- a/include/views.hpp
+++ b/include/views.hpp
@@ -44,15 +44,16 @@
 
 #pragma once
 
+#include <Kokkos_Core.hpp>
+#include <Kokkos_DynRankView.hpp>
+#include <iostream>
+
 #include "common.hpp"
 #include "concepts.hpp"
 #include "deep_copy.hpp"
 #include "defines.hpp"
 #include "fwd.hpp"
 #include "traits.hpp"
-
-#include <Kokkos_Core.hpp>
-#include <Kokkos_DynRankView.hpp>
 
 //----------------------------------------------------------------------------//
 

--- a/src/enumeration.cpp
+++ b/src/enumeration.cpp
@@ -42,15 +42,16 @@
 //@HEADER
 */
 
-#include "common.hpp"
-#include "defines.hpp"
-#include "fwd.hpp"
-#include "traits.hpp"
-
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 
 #include <cassert>
+#include <iostream>
+
+#include "common.hpp"
+#include "defines.hpp"
+#include "fwd.hpp"
+#include "traits.hpp"
 
 //----------------------------------------------------------------------------//
 


### PR DESCRIPTION
- header `<iostream>` was missing in a few location
- clang-format was applied at those locations (which induced header declaration re-ordering)
- notice: option `--cxx-standard 17` must be passed to setup.