### PR TITLE
requirements.txt: Updated python version >=3.9, <3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cmake>=3.16
-python>3.9,<3.12
+python>=3.9,<3.12
 scikit-build
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cmake>=3.16
+python>3.9,<3.12
 scikit-build
 numpy


### PR DESCRIPTION
Explicitly adding supported python versions in requirements.txt, as the setup or pykokkos is currently incompatible outside this range. 

Previously the environment defaulted to the latest python package (at this time 3.12.x), which is not supported.