### PR TITLE
ENH: add suppport for Kokkos::complex Views

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,8 @@ SET(libpykokkos_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/src/available.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/common.cpp
     ${CMAKE_CURRENT_LIST_DIR}/src/tools.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/src/execution_spaces.cpp)
+    ${CMAKE_CURRENT_LIST_DIR}/src/execution_spaces.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/complex_dtypes.cpp)
 
 SET(libpykokkos_HEADERS
     ${CMAKE_CURRENT_LIST_DIR}/include/libpykokkos.hpp

--- a/include/fwd.hpp
+++ b/include/fwd.hpp
@@ -134,6 +134,8 @@ enum KokkosViewDataType {
   Uint64,
   Float32,
   Float64,
+  ComplexFloat32,
+  ComplexFloat64,
   ViewDataTypesEnd
 };
 

--- a/include/traits.hpp
+++ b/include/traits.hpp
@@ -85,6 +85,10 @@ VIEW_DATA_TYPE(uint32_t, Uint32, "uint32", "unsigned", "unsigned_int")
 VIEW_DATA_TYPE(uint64_t, Uint64, "uint64", "unsigned_long")
 VIEW_DATA_TYPE(float, Float32, "float32", "float")
 VIEW_DATA_TYPE(double, Float64, "float64", "double")
+VIEW_DATA_TYPE(Kokkos::complex<float>, ComplexFloat32, "complex_float32_dtype",
+               "complex_float_dtype")
+VIEW_DATA_TYPE(Kokkos::complex<double>, ComplexFloat64, "complex_float64_dtype",
+               "complex_double_dtype")
 
 //----------------------------------------------------------------------------//
 // <data-type> <enum> <string identifiers>

--- a/include/views.hpp
+++ b/include/views.hpp
@@ -51,6 +51,7 @@
 #include "fwd.hpp"
 #include "traits.hpp"
 
+#include <pybind11/numpy.h>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_DynRankView.hpp>
 #include <iostream>

--- a/src/complex_dtypes.cpp
+++ b/src/complex_dtypes.cpp
@@ -42,21 +42,41 @@
 //@HEADER
 */
 
-#pragma once
-
 #include "common.hpp"
 
-#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <Kokkos_Core.hpp>
 
-namespace py = pybind11;
+//----------------------------------------------------------------------------//
+//
+//        The Kokkos::complex dtypes
+//
+//----------------------------------------------------------------------------//
 
-void generate_tools(py::module& kokkos);
-void generate_available(py::module& kokkos);
-void generate_enumeration(py::module& kokkos);
-void generate_view_variants(py::module& kokkos);
-void generate_atomic_variants(py::module& kokkos);
-void generate_backend_versions(py::module& kokkos);
-void generate_pool_variants(py::module& kokkos);
-void generate_execution_spaces(py::module& kokkos);
-void generate_complex_dtypes(py::module& kokkos);
-void destroy_callbacks();
+template <typename Tp>
+void generate_complex_dtype(py::module& kokkos, const std::string& _name) {
+  using ComplexTp = Kokkos::complex<Tp>;
+
+  py::class_<ComplexTp>(kokkos, _name.c_str())
+      .def(py::init<Tp>())      // Constructor for real part only
+      .def(py::init<Tp, Tp>())  // Constructor for real and imaginary parts
+      .def("imag_mutable", py::overload_cast<>(&ComplexTp::imag))
+      .def("imag_const", py::overload_cast<>(&ComplexTp::imag, py::const_))
+      .def("imag_set", py::overload_cast<Tp>(&ComplexTp::imag))
+      .def("real_mutable", py::overload_cast<>(&ComplexTp::real))
+      .def("real_const", py::overload_cast<>(&ComplexTp::real, py::const_))
+      .def("real_set", py::overload_cast<Tp>(&ComplexTp::real))
+      .def(py::self += py::self)
+      .def(py::self += Tp())
+      .def(py::self -= py::self)
+      .def(py::self -= Tp())
+      .def(py::self *= py::self)
+      .def(py::self *= Tp())
+      .def(py::self /= py::self)
+      .def(py::self /= Tp());
+}
+
+void generate_complex_dtypes(py::module& kokkos) {
+  generate_complex_dtype<float>(kokkos, "complex_float32");
+  generate_complex_dtype<double>(kokkos, "complex_float64");
+}

--- a/src/libpykokkos.cpp
+++ b/src/libpykokkos.cpp
@@ -116,4 +116,5 @@ PYBIND11_MODULE(libpykokkos, kokkos) {
   generate_backend_versions(kokkos);
   generate_pool_variants(kokkos);
   generate_execution_spaces(kokkos);
+  generate_complex_dtypes(kokkos);
 }

--- a/src/variants/CMakeLists.txt
+++ b/src/variants/CMakeLists.txt
@@ -26,7 +26,7 @@ TARGET_LINK_LIBRARIES(libpykokkos-variants PUBLIC
 
 SET(_types              concrete dynamic)
 SET(_variants           layout memory_trait)
-SET(_data_types         Int8 Int16 Int32 Int64 Uint8 Uint16 Uint32 Uint64 Float32 Float64)
+SET(_data_types         Int8 Int16 Int32 Int64 Uint8 Uint16 Uint32 Uint64 Float32 Float64 ComplexFloat32 ComplexFloat64)
 
 SET(layout_enums        Right)
 SET(memory_trait_enums  Managed)


### PR DESCRIPTION
This PR adds support for creating Views of type `Kokkos::complex<float>` and `Kokkos::complex<double>`. It also exposes these types to Python such that they can be created and used normally.