### PR TITLE
Update PyKokkos bindings for HIP for Kokkos v4.0

### DIFF
--- a/include/fwd.hpp
+++ b/include/fwd.hpp
@@ -63,8 +63,8 @@ class Serial;
 class Threads;
 class OpenMP;
 class Cuda;
-namespace Experimental {
 class HIP;
+namespace Experimental {
 class HPX;
 class OpenMPTarget;
 class SYCL;
@@ -84,12 +84,12 @@ class HostSpace;
 class CudaSpace;
 class CudaUVMSpace;
 class CudaHostPinnedSpace;
-// experimental spaces
-namespace Experimental {
-class HBWSpace;
 class HIPSpace;
 class HIPHostPinnedSpace;
 class HIPManagedSpace;
+// experimental spaces
+namespace Experimental {
+class HBWSpace;
 class OpenMPTargetSpace;
 class SYCLSharedUSMSpace;
 class SYCLDeviceUSMSpace;


### PR DESCRIPTION
HIP bindings moved from Experimental to main namespace.

NB: There may be other bindings in Kokkos that also has moved from Experimental, but here we only modify the HIP ones.