### PR TITLE
setup: disable `ninja` in order to compiler properly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ cmake_args = [
     f"-DPYTHON_EXECUTABLE:FILEPATH={sys.executable}",
     f"-DPython3_EXECUTABLE:FILEPATH={sys.executable}",
     "-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=ON",
+    "-G", "Unix Makefiles"
 ]
 
 parser = argparse.ArgumentParser(add_help=False)


### PR DESCRIPTION
This PR removes the effect of other build systems like `ninja` during the compilation process. 

pykokkos needs it, since the compilation stage loads the machine heavily, and the building stage needs to avoid any build systems.

For example, `ninja` would try to load all machine cores, which may lead to a system crash.

It was tested on the following machines and confirmed that the `ninja` causes this error:

```
OS: Pop!_OS 22.04 LTS x86_64
Kernel: 6.16.3-76061603-generic
CPU: AMD Ryzen 5 5600H (12) @ 4.280G
GPU: NVIDIA GeForce RTX 3050 Ti Mobile
Memory: 16GB
```

```
OS: Ubuntu 22.04.4 LTS x86_64
Kernel: 6.14.0-32-generic
CPU: Intel Xeon w5-3433 (32) @ 4.000GHz
GPU: NVIDIA ac:00.0 NVIDIA Corporation Device 26b2
GPU: NVIDIA ac:00.0 NVIDIA Corporation Device 26b2
Memory: 128GB
```